### PR TITLE
Send error from chatgpt.SendMessage, add tgbot package, conversations management by chatGPT 

### DIFF
--- a/main.go
+++ b/main.go
@@ -7,6 +7,7 @@ import (
 	"os/signal"
 	"strconv"
 	"syscall"
+	"time"
 
 	"github.com/joho/godotenv"
 	"github.com/m1guelpf/chatgpt-telegram/src/chatgpt"
@@ -41,7 +42,17 @@ func main() {
 		log.Fatalf("Couldn't load .env file: %v", err)
 	}
 
-	bot, err := tgbot.New(os.Getenv("TELEGRAM_TOKEN"))
+	editInterval := 1 * time.Second
+	if os.Getenv("EDIT_WAIT_SECONDS") != "" {
+		editSecond, err := strconv.ParseInt(os.Getenv("EDIT_WAIT_SECONDS"), 10, 64)
+		if err != nil {
+			log.Printf("Couldn't convert your edit seconds setting into int: %v", err)
+			editSecond = 1
+		}
+		editInterval = time.Duration(editSecond) * time.Second
+	}
+
+	bot, err := tgbot.New(os.Getenv("TELEGRAM_TOKEN"), editInterval)
 	if err != nil {
 		log.Fatalf("Couldn't start Telegram bot: %v", err)
 	}

--- a/src/tgbot/bot.go
+++ b/src/tgbot/bot.go
@@ -1,0 +1,103 @@
+package tgbot
+
+import (
+	"log"
+	"time"
+
+	tgbotapi "github.com/go-telegram-bot-api/telegram-bot-api/v5"
+	"github.com/m1guelpf/chatgpt-telegram/src/chatgpt"
+	"github.com/m1guelpf/chatgpt-telegram/src/markdown"
+	"github.com/m1guelpf/chatgpt-telegram/src/ratelimit"
+)
+
+type Bot struct {
+	Username string
+	api      *tgbotapi.BotAPI
+}
+
+func New(token string) (*Bot, error) {
+	api, err := tgbotapi.NewBotAPI(token)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Bot{
+		Username: api.Self.UserName,
+		api:      api,
+	}, nil
+}
+
+func (b *Bot) GetUpdatesChan() tgbotapi.UpdatesChannel {
+	cfg := tgbotapi.NewUpdate(0)
+	cfg.Timeout = 30
+	return b.api.GetUpdatesChan(cfg)
+}
+
+func (b *Bot) Stop() {
+	b.api.StopReceivingUpdates()
+}
+
+func (b *Bot) Send(chatID int64, replyTo int, text string) (tgbotapi.Message, error) {
+	text = markdown.EnsureFormatting(text)
+	msg := tgbotapi.NewMessage(chatID, text)
+	msg.ReplyToMessageID = replyTo
+	return b.api.Send(msg)
+}
+
+func (b *Bot) SendEdit(chatID int64, messageID int, text string) error {
+	text = markdown.EnsureFormatting(text)
+	msg := tgbotapi.NewEditMessageText(chatID, messageID, text)
+	msg.ParseMode = "Markdown"
+	if _, err := b.api.Send(msg); err != nil {
+		if err.Error() == "Bad Request: message is not modified: specified new message content and reply markup are exactly the same as a current content and reply markup of the message" {
+			return nil
+		}
+		return err
+	}
+	return nil
+}
+
+func (b *Bot) SendTyping(chatID int64) {
+	if _, err := b.api.Request(tgbotapi.NewChatAction(chatID, "typing")); err != nil {
+		log.Printf("Couldn't send typing action: %v", err)
+	}
+}
+
+func (b *Bot) SendAsLiveOutput(chatID int64, replyTo int, feed chan chatgpt.ChatResponse) {
+	debouncedType := ratelimit.Debounce(10*time.Second, func() { b.SendTyping(chatID) })
+	debouncedEdit := ratelimit.DebounceWithArgs(time.Second, func(text interface{}, messageId interface{}) {
+		if err := b.SendEdit(chatID, messageId.(int), text.(string)); err != nil {
+			log.Printf("Couldn't edit message: %v", err)
+		}
+	})
+
+	var message tgbotapi.Message
+	var lastResp string
+
+pollResponse:
+	for {
+		debouncedType()
+
+		select {
+		case response, ok := <-feed:
+			if !ok {
+				break pollResponse
+			}
+
+			lastResp = response.Message
+
+			if message.MessageID == 0 {
+				var err error
+				if message, err = b.Send(chatID, replyTo, lastResp); err != nil {
+					log.Fatalf("Couldn't send message: %v", err)
+				}
+			} else {
+				debouncedEdit(lastResp, message.MessageID)
+			}
+		}
+	}
+
+	if err := b.SendEdit(chatID, message.MessageID, lastResp); err != nil {
+		log.Printf("Couldn't perform final edit on message: %v", err)
+	}
+}


### PR DESCRIPTION
Was initially planning on fixing sending of error from `SendMessage` only, but felt hesitant on growing the `main` function further so came the moving of things around.

Conversation management (i.e. mapping from `chatID` to `conversationID` and `lastMessageID`) felt heavily coupled to the `chatgpt` package, so have moved that there. This data (convoID & lastMessageID) is now not used in any other packages, so `ChatResponse` updated to only contain the `Message`.

A lot of logic in the main around sending a message through `tgbotapi`, similarly to other packages imo this deserved a thin wrapper package, exposing methods like: `Send`, `SendAsLiveOutput`.

